### PR TITLE
fix: 하단 탭 표시 여부 추가

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+// 하단 탭바를 관리하기 위한 상태 클래스
+class AppState extends ChangeNotifier {
+  bool _showBottomTab = true;
+
+  bool get showBottomTab => _showBottomTab;
+
+  void setBottomTabVisibility(bool show) {
+    if (_showBottomTab != show) {
+      _showBottomTab = show;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/bottom_tab.dart
+++ b/lib/bottom_tab.dart
@@ -1,10 +1,13 @@
+import 'dart:developer';
+import 'package:fapp/app_state.dart';
+import 'package:fapp/bottom_tab_route_observer.dart';
 import 'package:fapp/record/record_select_description.dart';
 import 'package:fapp/record/record_select_moment.dart';
 import 'package:fapp/screens/emotion_home.dart';
-import 'package:fapp/mock/emotion_summary.dart';
-import 'package:fapp/settings/components/setting_profile_container.dart';
+import 'package:fapp/settings/setting_profile_container.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:provider/provider.dart';
 
 class BottomTab extends StatefulWidget {
   const BottomTab({super.key});
@@ -17,7 +20,6 @@ class _BottomTabState extends State<BottomTab>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
   late PageController _pageController;
-  final bioMockData = MockData.bioMockData;
 
   int _selectedIndex = 0;
   List<Map<String, dynamic>> tabData = [
@@ -43,6 +45,11 @@ class _BottomTabState extends State<BottomTab>
     },
   ];
 
+  final List<GlobalKey<NavigatorState>> _navigatorKeys = List.generate(
+    4,
+    (_) => GlobalKey<NavigatorState>(),
+  );
+
   @override
   void initState() {
     super.initState();
@@ -55,7 +62,7 @@ class _BottomTabState extends State<BottomTab>
     });
   }
 
-  @override // 부모 dispose를 상속받아 객체(_*Controller)가 사용하던 리소스를 해제하는 역할
+  @override
   void dispose() {
     _tabController.dispose();
     _pageController.dispose();
@@ -64,70 +71,103 @@ class _BottomTabState extends State<BottomTab>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text("")),
-      bottomNavigationBar: SizedBox(
-        height: 75,
-        child: TabBar(
-          indicatorColor: Colors.transparent,
-          // padding: EdgeInsets.symmetric(vertical: 5.0),
-          labelColor: Colors.black,
-          controller: _tabController,
-          overlayColor: WidgetStateProperty.all(
-            Colors.transparent,
-          ), //만약 탭바를 눌렀을 때 눌린 효과를 주려면 이 코드 제거
-          onTap: (index) {
-            _pageController.jumpToPage(index);
-          },
-          tabs: List.generate(tabData.length, (index) {
-            return Tab(
-              icon: SvgPicture.asset(
-                _selectedIndex == index
-                    ? tabData[index]['iconActive']
-                    : tabData[index]['iconInactive'],
-              ),
-              child: Text(
-                tabData[index]['text'],
-                style: TextStyle(
-                  color:
-                      _selectedIndex == index
-                          ? const Color(0xFF8749EB)
-                          : const Color(0xFF9FA0A0),
-                ),
-              ),
-            );
-          }),
-        ),
-      ),
-      body: PageView(
-        controller: _pageController,
-        physics:
-            const NeverScrollableScrollPhysics(), // 나중에 페이지를 스와이프해서 넘길 경우 이 코드 제거
-        onPageChanged: (index) {
-          setState(() {
-            _selectedIndex = index;
-            _tabController.animateTo(index);
-          });
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) {
+          return;
+        }
+        final isFirstRouteInCurrentTab =
+            !await _navigatorKeys[_selectedIndex].currentState!.maybePop();
+        if (isFirstRouteInCurrentTab) {
+          log('앱 종료');
+        }
+      },
+      child: Consumer<AppState>(
+        builder: (context, appState, child) {
+          return Scaffold(
+            resizeToAvoidBottomInset: true,
+            appBar: AppBar(title: const Text("")),
+            // AppState에 따라 바텀 탭바 표시 여부 결정
+            bottomNavigationBar:
+                appState.showBottomTab
+                    ? SizedBox(
+                      height: 75,
+                      child: TabBar(
+                        indicatorColor: Colors.transparent,
+                        labelColor: Colors.black,
+                        controller: _tabController,
+                        overlayColor: WidgetStateProperty.all(
+                          Colors.transparent,
+                        ),
+                        onTap: (index) {
+                          _pageController.jumpToPage(index);
+                        },
+                        tabs: List.generate(tabData.length, (index) {
+                          return Tab(
+                            icon: SvgPicture.asset(
+                              _selectedIndex == index
+                                  ? tabData[index]['iconActive']
+                                  : tabData[index]['iconInactive'],
+                            ),
+                            child: Text(
+                              tabData[index]['text'],
+                              style: TextStyle(
+                                color:
+                                    _selectedIndex == index
+                                        ? const Color(0xFF8749EB)
+                                        : const Color(0xFF9FA0A0),
+                              ),
+                            ),
+                          );
+                        }),
+                      ),
+                    )
+                    : null,
+            body: PageView(
+              controller: _pageController,
+              physics: const NeverScrollableScrollPhysics(),
+              onPageChanged: (index) {
+                setState(() {
+                  _selectedIndex = index;
+                  _tabController.animateTo(index);
+                });
+              },
+              children: List.generate(tabData.length, (index) {
+                return Navigator(
+                  key: _navigatorKeys[index],
+                  initialRoute: '/',
+                  // RouteObserver 등록
+                  observers: [Provider.of<BottomTabRouteObserver>(context)],
+                  onGenerateRoute: (routeSettings) {
+                    WidgetBuilder builder;
+                    switch (index) {
+                      case 0:
+                        builder = (context) => HomeScreen();
+                        break;
+                      case 1:
+                        builder = (context) => const RecordSelectMoment();
+                        break;
+                      case 2:
+                        builder = (context) => const RecordSelectDescription();
+                        break;
+                      case 3:
+                        builder = (context) => SettingProfileContainer();
+                        break;
+                      default:
+                        throw Exception('Invalid index: $index');
+                    }
+                    return MaterialPageRoute(
+                      builder: builder,
+                      settings: routeSettings,
+                    );
+                  },
+                );
+              }),
+            ),
+          );
         },
-        children: [
-          tabContainer(
-            context,
-            const Color.fromARGB(128, 29, 141, 182),
-            HomeScreen(),
-          ),
-          tabContainer(context, Colors.amber[600]!, const RecordSelectMoment()),
-          tabContainer(
-            context,
-            Colors.blueGrey,
-            const RecordSelectDescription(),
-          ),
-          tabContainer(context, Colors.green, SettingProfileContainer()),
-        ],
       ),
     );
-  }
-
-  Widget tabContainer(BuildContext context, Color tabColor, Widget child) {
-    return child;
   }
 }

--- a/lib/bottom_tab.dart
+++ b/lib/bottom_tab.dart
@@ -141,18 +141,23 @@ class _BottomTabState extends State<BottomTab>
                   observers: [Provider.of<BottomTabRouteObserver>(context)],
                   onGenerateRoute: (routeSettings) {
                     WidgetBuilder builder;
+                    String routeName;
                     switch (index) {
                       case 0:
                         builder = (context) => HomeScreen();
+                        routeName = '/';
                         break;
                       case 1:
                         builder = (context) => const RecordSelectMoment();
+                        routeName = '/record-select-moment';
                         break;
                       case 2:
                         builder = (context) => const RecordSelectDescription();
+                        routeName = '/record-select-description';
                         break;
                       case 3:
                         builder = (context) => SettingProfileContainer();
+                        routeName = '/profile';
                         break;
                       default:
                         throw Exception('Invalid index: $index');

--- a/lib/bottom_tab.dart
+++ b/lib/bottom_tab.dart
@@ -1,8 +1,5 @@
 import 'dart:developer';
 import 'package:fapp/app_state.dart';
-import 'package:fapp/bottom_tab_route_observer.dart';
-import 'package:fapp/record/record_select_description.dart';
-import 'package:fapp/record/record_select_moment.dart';
 import 'package:fapp/screens/emotion_home.dart';
 import 'package:fapp/settings/setting_profile_container.dart';
 import 'package:flutter/material.dart';
@@ -45,11 +42,6 @@ class _BottomTabState extends State<BottomTab>
     },
   ];
 
-  final List<GlobalKey<NavigatorState>> _navigatorKeys = List.generate(
-    4,
-    (_) => GlobalKey<NavigatorState>(),
-  );
-
   @override
   void initState() {
     super.initState();
@@ -77,18 +69,16 @@ class _BottomTabState extends State<BottomTab>
         if (didPop) {
           return;
         }
-        final isFirstRouteInCurrentTab =
-            !await _navigatorKeys[_selectedIndex].currentState!.maybePop();
-        if (isFirstRouteInCurrentTab) {
+        if (_selectedIndex == 0) {
           log('앱 종료');
+        } else {
+          _tabController.animateTo(0);
         }
       },
       child: Consumer<AppState>(
         builder: (context, appState, child) {
           return Scaffold(
             resizeToAvoidBottomInset: true,
-            appBar: AppBar(title: const Text("")),
-            // AppState에 따라 바텀 탭바 표시 여부 결정
             bottomNavigationBar:
                 appState.showBottomTab
                     ? SizedBox(
@@ -133,42 +123,30 @@ class _BottomTabState extends State<BottomTab>
                   _tabController.animateTo(index);
                 });
               },
-              children: List.generate(tabData.length, (index) {
-                return Navigator(
-                  key: _navigatorKeys[index],
+              children: [
+                Navigator(
+                  key: const ValueKey('home_navigator'),
                   initialRoute: '/',
-                  // RouteObserver 등록
-                  observers: [Provider.of<BottomTabRouteObserver>(context)],
                   onGenerateRoute: (routeSettings) {
-                    WidgetBuilder builder;
-                    String routeName;
-                    switch (index) {
-                      case 0:
-                        builder = (context) => HomeScreen();
-                        routeName = '/';
-                        break;
-                      case 1:
-                        builder = (context) => const RecordSelectMoment();
-                        routeName = '/record-select-moment';
-                        break;
-                      case 2:
-                        builder = (context) => const RecordSelectDescription();
-                        routeName = '/record-select-description';
-                        break;
-                      case 3:
-                        builder = (context) => SettingProfileContainer();
-                        routeName = '/profile';
-                        break;
-                      default:
-                        throw Exception('Invalid index: $index');
-                    }
                     return MaterialPageRoute(
-                      builder: builder,
+                      builder: (context) => HomeScreen(),
                       settings: routeSettings,
                     );
                   },
-                );
-              }),
+                ),
+                const Center(child: Text('1')),
+                const Center(child: Text('2')),
+                Navigator(
+                  key: const ValueKey('profile_navigator'),
+                  initialRoute: '/profile',
+                  onGenerateRoute: (routeSettings) {
+                    return MaterialPageRoute(
+                      builder: (context) => SettingProfileContainer(),
+                      settings: routeSettings,
+                    );
+                  },
+                ),
+              ],
             ),
           );
         },

--- a/lib/bottom_tab_route_observer.dart
+++ b/lib/bottom_tab_route_observer.dart
@@ -22,7 +22,10 @@ class BottomTabRouteObserver extends RouteObserver<PageRoute<dynamic>> {
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
-    if (previousRoute != null) {
+    if (route.settings.name == '/record-select-moment' &&
+        previousRoute?.settings.name == '/') {
+      onShowBottomTab(true);
+    } else if (previousRoute != null) {
       _updateBottomTabVisibility(previousRoute);
     }
   }
@@ -40,7 +43,8 @@ class BottomTabRouteObserver extends RouteObserver<PageRoute<dynamic>> {
       final routeName = route.settings.name;
       final hideBottomTab =
           routeName != null && routesWithoutBottomTab.contains(routeName);
-      onShowBottomTab(!hideBottomTab);
+      final show = !hideBottomTab;
+      onShowBottomTab(show);
     }
   }
 }

--- a/lib/bottom_tab_route_observer.dart
+++ b/lib/bottom_tab_route_observer.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+// 라우트 옵저버를 통해 페이지(라우트)변경을 감지하여 표시 여부
+class BottomTabRouteObserver extends RouteObserver<PageRoute<dynamic>> {
+  final Function(bool) onShowBottomTab;
+
+  final List<String> routesWithoutBottomTab = [
+    '/record-select-moment',
+    '/record-select-emotion',
+    '/record-select-expressions',
+    '/record-select-description',
+  ];
+
+  BottomTabRouteObserver({required this.onShowBottomTab});
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _updateBottomTabVisibility(route);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    if (previousRoute != null) {
+      _updateBottomTabVisibility(previousRoute);
+    }
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    if (newRoute != null) {
+      _updateBottomTabVisibility(newRoute);
+    }
+  }
+
+  void _updateBottomTabVisibility(Route<dynamic> route) {
+    if (route is PageRoute) {
+      final routeName = route.settings.name;
+      final hideBottomTab =
+          routeName != null && routesWithoutBottomTab.contains(routeName);
+      onShowBottomTab(!hideBottomTab);
+    }
+  }
+}

--- a/lib/emotion/emotion_moment_section.dart
+++ b/lib/emotion/emotion_moment_section.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 import 'dart:developer';
 
+import 'package:fapp/app_state.dart';
 import 'package:fapp/emotion/emotion_no_summary_item.dart';
 import 'package:fapp/emotion/emotion_summary_day_box.dart';
 import 'package:fapp/emotion/emtion_all_items.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class MomentEmotionSection extends StatefulWidget {
@@ -59,13 +60,16 @@ class _MomentEmotionSectionState extends State<MomentEmotionSection> {
 
   void _handleShowAllEmotions(BuildContext context) {
     if (emotions != null) {
+      final appState = Provider.of<AppState>(context, listen: false);
+      appState.setBottomTabVisibility(false);
+
       showModalBottomSheet(
         context: context,
         isScrollControlled: true,
         backgroundColor: Colors.transparent,
         builder:
-            (context) => Container(
-              height: MediaQuery.of(context).size.height * 0.85,
+            (modalContext) => Container(
+              height: MediaQuery.of(context).size.height * 0.75,
               decoration: const BoxDecoration(
                 color: Color(0xFFC9C4F2),
                 borderRadius: BorderRadius.only(
@@ -92,7 +96,9 @@ class _MomentEmotionSectionState extends State<MomentEmotionSection> {
                           ),
                         ),
                         GestureDetector(
-                          onTap: () => Navigator.of(context).pop(),
+                          onTap: () {
+                            Navigator.of(modalContext).pop();
+                          },
                           child: const Text(
                             '완료',
                             style: TextStyle(
@@ -107,10 +113,6 @@ class _MomentEmotionSectionState extends State<MomentEmotionSection> {
                   ),
                   Expanded(
                     child: ClipRRect(
-                      // borderRadius: const BorderRadius.only(
-                      //   topLeft: Radius.circular(20),
-                      //   topRight: Radius.circular(20),
-                      // ),
                       child: AllEmotionsModal(
                         emotions: emotions!,
                         date: widget.date,
@@ -125,7 +127,11 @@ class _MomentEmotionSectionState extends State<MomentEmotionSection> {
                 ],
               ),
             ),
-      );
+      ).then((_) {
+        if (mounted) {
+          appState.setBottomTabVisibility(true);
+        }
+      });
     }
   }
 
@@ -152,7 +158,6 @@ class _MomentEmotionSectionState extends State<MomentEmotionSection> {
             : const NoEmotionSummaryDayBox(),
         if (emotions != null && emotions!.isNotEmpty)
           GestureDetector(
-            // Positioned 대신 GestureDetector로 감싸고
             onTap: () => _handleShowAllEmotions(context),
             child: Container(
               decoration: const BoxDecoration(

--- a/lib/emotion/emotion_moment_section.dart
+++ b/lib/emotion/emotion_moment_section.dart
@@ -37,7 +37,6 @@ class _MomentEmotionSectionState extends State<MomentEmotionSection> {
   @override
   void initState() {
     super.initState();
-    log('MomentEmotionSection initState - widget.date: ${widget.date}');
     _loadEmotionsForDate();
   }
 
@@ -137,7 +136,6 @@ class _MomentEmotionSectionState extends State<MomentEmotionSection> {
 
   @override
   Widget build(BuildContext context) {
-    log('LocalEmotions -> $emotions');
     return Column(
       children: [
         const Text(

--- a/lib/emotion/emotion_summary_container.dart
+++ b/lib/emotion/emotion_summary_container.dart
@@ -36,6 +36,8 @@ class EmotionSummaryContainer extends StatelessWidget {
               Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (context) => const RecordSelectMoment(),
+                  settings: const RouteSettings(name: '/record-select-moment'),
+                  barrierDismissible: true,
                 ),
               );
             },

--- a/lib/emotion/emotion_summary_container.dart
+++ b/lib/emotion/emotion_summary_container.dart
@@ -37,7 +37,6 @@ class EmotionSummaryContainer extends StatelessWidget {
                 MaterialPageRoute(
                   builder: (context) => const RecordSelectMoment(),
                   settings: const RouteSettings(name: '/record-select-moment'),
-                  barrierDismissible: true,
                 ),
               );
             },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,12 +31,17 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final routeObserver = Provider.of<BottomTabRouteObserver>(
+      context,
+      listen: false,
+    );
     return MaterialApp(
       title: 'Fitus',
       theme: ThemeData(primarySwatch: Colors.blue),
       debugShowCheckedModeBanner: false,
       home: const BottomTab(),
       routes: {"/emotion-calendar": (context) => EmotionCalendarPage()},
+      navigatorObservers: [routeObserver],
       onGenerateRoute: (settings) {
         return null;
       },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,8 +35,11 @@ class MyApp extends StatelessWidget {
       title: 'Fitus',
       theme: ThemeData(primarySwatch: Colors.blue),
       debugShowCheckedModeBanner: false,
-      home: const Home(),
+      home: const BottomTab(),
       routes: {"/emotion-calendar": (context) => EmotionCalendarPage()},
+      onGenerateRoute: (settings) {
+        return null;
+      },
     );
   }
 }
@@ -52,12 +55,7 @@ class Home extends StatelessWidget {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              // child: Center(child: BioDashboard(data: bioMockData)),
-            ),
-          ),
+          Expanded(child: Padding(padding: const EdgeInsets.all(20))),
           const SizedBox(height: 30),
         ],
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,25 @@
+import 'package:fapp/app_state.dart';
 import 'package:fapp/bottom_tab.dart';
+import 'package:fapp/bottom_tab_route_observer.dart';
 import 'package:flutter/material.dart';
 import 'package:fapp/record/record_context.dart';
 import 'package:provider/provider.dart';
 
 void main() {
+  final appState = AppState();
+  final routeObserver = BottomTabRouteObserver(
+    onShowBottomTab: (show) {
+      appState.setBottomTabVisibility(show);
+    },
+  );
+
   runApp(
-    ChangeNotifierProvider(
-      create: (_) => RecordContext(),
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider.value(value: appState),
+        ChangeNotifierProvider(create: (_) => RecordContext()),
+        Provider.value(value: routeObserver),
+      ],
       child: const MyApp(),
     ),
   );
@@ -18,7 +31,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'BioScore Demo',
+      title: 'Fitus',
       theme: ThemeData(primarySwatch: Colors.blue),
       debugShowCheckedModeBanner: false,
       home: const Home(),

--- a/lib/record/components/record_app_bar_android.dart
+++ b/lib/record/components/record_app_bar_android.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'dart:io';
+import 'package:provider/provider.dart';
+import 'package:fapp/app_state.dart';
+import 'package:fapp/screens/emotion_home.dart';
 
 class RecordAppBarAndroid extends StatelessWidget
     implements PreferredSizeWidget {
@@ -13,41 +16,33 @@ class RecordAppBarAndroid extends StatelessWidget
   Widget build(BuildContext context) {
     return AppBar(
       title: const Text(""),
-      //     backgroundColor:
-      //         Theme.of(context).colorScheme.primaryContainer, // 필요에 따라 색상 변경
-      //     title: const Center(
-      //       child: Text(
-      //         "감정 기록",
-      //         style: TextStyle(
-      //           fontWeight: FontWeight.bold,
-      //           fontSize: 18.0,
-      //           color: Colors.black87,
-      //         ),
-      //       ),
-      //     ),
-      //     leading: IconButton(
-      //       icon: const Icon(Icons.arrow_back_ios_new),
-      //       onPressed: () {
-      //         Navigator.of(context).pop();
-      //       },
-      //       color: Colors.black87,
-      //     ),
-      //     actions: [
-      //       TextButton(
-      //         onPressed: () {
-      //           Navigator.of(
-      //             context,
-      //           ).push(MaterialPageRoute(builder: (context) => const HomeScreen()));
-      //         },
-      //         child: const Text(
-      //           "취소",
-      //           style: TextStyle(fontSize: 16.0, color: Colors.black87),
-      //         ),
-      //       ),
-      //     ],
-      //     elevation: 1,
-      //   );
-      // }
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        onPressed: () {
+          if (ModalRoute.of(context)?.settings.name ==
+              '/record-select-moment') {
+            Provider.of<AppState>(
+              context,
+              listen: false,
+            ).setBottomTabVisibility(true);
+          }
+          Navigator.of(context).pop();
+        },
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Provider.of<AppState>(
+              context,
+              listen: false,
+            ).setBottomTabVisibility(true);
+            Navigator.of(context).pushReplacement(
+              MaterialPageRoute(builder: (context) => const HomeScreen()),
+            );
+          },
+          child: const Text("취소"),
+        ),
+      ],
     );
   }
 }

--- a/lib/record/components/record_app_bar_ios.dart
+++ b/lib/record/components/record_app_bar_ios.dart
@@ -1,7 +1,9 @@
+import 'package:fapp/app_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'dart:io';
 import 'package:fapp/screens/emotion_home.dart';
+import 'package:provider/provider.dart';
 
 class RecordAppBarIos extends StatelessWidget
     implements ObstructingPreferredSizeWidget {
@@ -32,11 +34,17 @@ class RecordAppBarIos extends StatelessWidget
         ),
       ),
       leading: CupertinoNavigationBarBackButton(
-        // Changed from CupertinoButton
-        onPressed: () => Navigator.of(context).pop(),
-        color:
-            CupertinoColors
-                .systemBlue, // Added color to match the original button
+        onPressed: () {
+          if (ModalRoute.of(context)?.settings.name ==
+              '/record-select-moment') {
+            Provider.of<AppState>(
+              context,
+              listen: false,
+            ).setBottomTabVisibility(true);
+          }
+          Navigator.of(context).pop();
+        },
+        color: CupertinoColors.systemBlue,
       ),
       trailing: CupertinoButton(
         padding: EdgeInsets.zero,
@@ -45,6 +53,10 @@ class RecordAppBarIos extends StatelessWidget
           style: TextStyle(fontSize: 16.0, color: CupertinoColors.systemBlue),
         ),
         onPressed: () {
+          Provider.of<AppState>(
+            context,
+            listen: false,
+          ).setBottomTabVisibility(true);
           Navigator.of(
             context,
           ).push(CupertinoPageRoute(builder: (context) => const HomeScreen()));

--- a/lib/record/record_select_description.dart
+++ b/lib/record/record_select_description.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fapp/app_state.dart';
 import 'package:fapp/record/components/record_app_bar_android.dart';
 import 'package:fapp/record/components/record_app_bar_ios.dart';
 import 'package:fapp/screens/emotion_home.dart';
@@ -122,8 +123,15 @@ class _RecordSelectDescriptionState extends State<RecordSelectDescription> {
       submitEmotion();
       recordContext.setEmotion(0);
       recordContext.setMoment("");
+      Provider.of<AppState>(
+        context,
+        listen: false,
+      ).setBottomTabVisibility(true);
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (context) => const HomeScreen()),
+        MaterialPageRoute(
+          builder: (context) => const HomeScreen(),
+          settings: const RouteSettings(name: '/'),
+        ),
       );
     }
 

--- a/lib/record/record_select_description.dart
+++ b/lib/record/record_select_description.dart
@@ -27,11 +27,9 @@ class _RecordSelectDescriptionState extends State<RecordSelectDescription> {
   String _description = "";
   bool _localeInitialized = false;
 
-  // TextField controllers
   late TextEditingController _placeController;
   late TextEditingController _descriptionController;
 
-  // 스타일 상수 정의
   static const TextStyle _titleStyle = TextStyle(fontSize: 16.0);
   static const TextStyle _textFieldLabelStyle = TextStyle(
     fontSize: 14.0,
@@ -129,39 +127,41 @@ class _RecordSelectDescriptionState extends State<RecordSelectDescription> {
       );
     }
 
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: paletteItem.backgroundColor,
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
+    return Material(
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: paletteItem.backgroundColor,
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                ),
               ),
             ),
           ),
-        ),
-        Positioned.fill(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: Column(
-              children: [
-                _buildEmotionSection(paletteItem, emotionText, expressions),
-                _buildInputSection(context),
-                Padding(
-                  padding: const EdgeInsets.only(top: 16.0, bottom: 16.0),
-                  child: RecordNextButton(
-                    text: "기록하기",
-                    onPressed: handleNext,
-                    buttonColor: paletteItem.buttonColor,
+          Positioned.fill(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Column(
+                children: [
+                  _buildEmotionSection(paletteItem, emotionText, expressions),
+                  _buildInputSection(context),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 16.0, bottom: 16.0),
+                    child: RecordNextButton(
+                      text: "기록하기",
+                      onPressed: handleNext,
+                      buttonColor: paletteItem.buttonColor,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/lib/record/record_select_emotion.dart
+++ b/lib/record/record_select_emotion.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:fapp/bottom_tab_route_observer.dart';
 import 'package:fapp/record/components/emotion/record_emotion_background.dart';
 import 'package:fapp/record/components/emotion/record_emotion_header.dart';
 import 'package:fapp/record/components/emotion/record_emotion_image.dart';
@@ -24,7 +25,7 @@ class SelectEmotionScreen extends StatefulWidget {
 }
 
 class SelectEmotionScreenState extends State<SelectEmotionScreen>
-    with TickerProviderStateMixin {
+    with TickerProviderStateMixin, RouteAware {
   int _emotion = 0;
   int _prevEmotion = 0;
   late EmotionAnimations _animations;
@@ -39,7 +40,22 @@ class SelectEmotionScreenState extends State<SelectEmotionScreen>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final routeObserver = Provider.of<BottomTabRouteObserver>(
+      context,
+      listen: false,
+    );
+    routeObserver.subscribe(this, ModalRoute.of(context) as PageRoute);
+  }
+
+  @override
   void dispose() {
+    final routeObserver = Provider.of<BottomTabRouteObserver>(
+      context,
+      listen: false,
+    );
+    routeObserver.unsubscribe(this);
     _animations.dispose();
     super.dispose();
   }
@@ -50,6 +66,7 @@ class SelectEmotionScreenState extends State<SelectEmotionScreen>
       context,
       MaterialPageRoute(
         builder: (context) => EmotionExpressScreen(emotionIndex: _emotion),
+        settings: const RouteSettings(name: '/record-select-moment'),
       ),
     );
   }

--- a/lib/record/record_select_expressions.dart
+++ b/lib/record/record_select_expressions.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 import 'dart:io';
+import 'package:fapp/bottom_tab_route_observer.dart';
 import 'package:fapp/record/components/record_app_bar_android.dart';
 import 'package:fapp/record/components/record_app_bar_ios.dart';
 import 'package:fapp/record/components/record_expression_box.dart';
@@ -10,7 +11,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class EmotionExpressScreen extends StatefulWidget {
+class EmotionExpressScreen extends StatefulWidget with RouteAware {
   const EmotionExpressScreen({super.key, required this.emotionIndex});
 
   final int emotionIndex;
@@ -19,12 +20,33 @@ class EmotionExpressScreen extends StatefulWidget {
   State<EmotionExpressScreen> createState() => _EmotionExpressScreenState();
 }
 
-class _EmotionExpressScreenState extends State<EmotionExpressScreen> {
+class _EmotionExpressScreenState extends State<EmotionExpressScreen>
+    with RouteAware {
   List<String> selectedExpressions = [];
   String get emotionText => _getEmotionText(widget.emotionIndex);
 
   void setExpressions(List<String> expressions) {
     log("Setting expressions: $expressions");
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final routeObserver = Provider.of<BottomTabRouteObserver>(
+      context,
+      listen: false,
+    );
+    routeObserver.subscribe(this, ModalRoute.of(context) as PageRoute);
+  }
+
+  @override
+  void dispose() {
+    final routeObserver = Provider.of<BottomTabRouteObserver>(
+      context,
+      listen: false,
+    );
+    routeObserver.unsubscribe(this);
+    super.dispose();
   }
 
   void handleNext() {
@@ -37,7 +59,10 @@ class _EmotionExpressScreenState extends State<EmotionExpressScreen> {
     });
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (context) => const RecordSelectDescription()),
+      MaterialPageRoute(
+        builder: (context) => const RecordSelectDescription(),
+        settings: const RouteSettings(name: '/record-select-description'),
+      ),
     );
   }
 
@@ -93,10 +118,7 @@ class _EmotionExpressScreenState extends State<EmotionExpressScreen> {
         ? CupertinoPageScaffold(
           resizeToAvoidBottomInset: true,
           navigationBar: RecordAppBarIos(title: ""),
-          child: Material(
-            // Wrap with Material on iOS
-            child: SafeArea(child: _buildContent(context)),
-          ),
+          child: Material(child: SafeArea(child: _buildContent(context))),
         )
         : Scaffold(
           appBar: const RecordAppBarAndroid(),

--- a/lib/record/record_select_expressions.dart
+++ b/lib/record/record_select_expressions.dart
@@ -40,6 +40,11 @@ class _EmotionExpressScreenState extends State<EmotionExpressScreen>
   }
 
   @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
   void dispose() {
     final routeObserver = Provider.of<BottomTabRouteObserver>(
       context,

--- a/lib/record/record_select_moment.dart
+++ b/lib/record/record_select_moment.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:fapp/app_state.dart';
 import 'package:fapp/bottom_tab_route_observer.dart';
 import 'package:fapp/record/components/moment/record_moment_header.dart';
+import 'package:fapp/record/components/record_app_bar_android.dart';
 import 'package:fapp/record/components/record_app_bar_ios.dart';
 import 'package:fapp/record/components/record_next_button.dart';
 import 'package:fapp/record/components/moment/record_moment_select_box.dart';
@@ -141,7 +142,7 @@ class _RecordSelectMomentState extends State<RecordSelectMoment>
           ),
         )
         : Scaffold(
-          appBar: AppBar(title: const Text("")),
+          appBar: const RecordAppBarAndroid(),
           body: SafeArea(
             child: _buildContent(context, now, nowTimes, currentPalette),
           ),

--- a/lib/record/record_select_moment.dart
+++ b/lib/record/record_select_moment.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 import 'dart:io';
+import 'package:fapp/bottom_tab_route_observer.dart';
 import 'package:fapp/record/components/moment/record_moment_header.dart';
 import 'package:fapp/record/components/record_app_bar_ios.dart';
 import 'package:fapp/record/components/record_next_button.dart';
@@ -18,8 +19,29 @@ class RecordSelectMoment extends StatefulWidget {
   State<RecordSelectMoment> createState() => _RecordSelectMomentState();
 }
 
-class _RecordSelectMomentState extends State<RecordSelectMoment> {
+class _RecordSelectMomentState extends State<RecordSelectMoment>
+    with RouteAware {
   String? _selectedMoment;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final routeObserver = Provider.of<BottomTabRouteObserver>(
+      context,
+      listen: false,
+    );
+    routeObserver.subscribe(this, ModalRoute.of(context) as PageRoute);
+  }
+
+  @override
+  void dispose() {
+    final routeObserver = Provider.of<BottomTabRouteObserver>(
+      context,
+      listen: false,
+    );
+    routeObserver.unsubscribe(this);
+    super.dispose();
+  }
 
   void _handleSelect(String moment) {
     setState(() {
@@ -64,7 +86,7 @@ class _RecordSelectMomentState extends State<RecordSelectMoment> {
             CupertinoDialogAction(
               child: const Text("확인"),
               onPressed: () {
-                log("Alert닫");
+                log("Alert닫힘");
                 Navigator.of(context).pop();
               },
             ),
@@ -79,7 +101,10 @@ class _RecordSelectMomentState extends State<RecordSelectMoment> {
       log('Navigating to /screens/form-select-emotion');
       Navigator.push(
         context,
-        MaterialPageRoute(builder: (context) => SelectEmotionScreen()),
+        MaterialPageRoute(
+          builder: (context) => SelectEmotionScreen(),
+          settings: const RouteSettings(name: '/record-select-emotion'),
+        ),
       );
     } else {
       _showSelectionAlert();

--- a/lib/record/record_select_moment.dart
+++ b/lib/record/record_select_moment.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 import 'dart:io';
+import 'package:fapp/app_state.dart';
 import 'package:fapp/bottom_tab_route_observer.dart';
 import 'package:fapp/record/components/moment/record_moment_header.dart';
 import 'package:fapp/record/components/record_app_bar_ios.dart';
@@ -22,24 +23,33 @@ class RecordSelectMoment extends StatefulWidget {
 class _RecordSelectMomentState extends State<RecordSelectMoment>
     with RouteAware {
   String? _selectedMoment;
+  BottomTabRouteObserver? _routeObserver;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Provider.of<AppState>(
+        context,
+        listen: false,
+      ).setBottomTabVisibility(false);
+    });
+  }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final routeObserver = Provider.of<BottomTabRouteObserver>(
+    _routeObserver = Provider.of<BottomTabRouteObserver>(
       context,
       listen: false,
     );
-    routeObserver.subscribe(this, ModalRoute.of(context) as PageRoute);
+    _routeObserver?.subscribe(this, ModalRoute.of(context) as PageRoute);
   }
 
   @override
   void dispose() {
-    final routeObserver = Provider.of<BottomTabRouteObserver>(
-      context,
-      listen: false,
-    );
-    routeObserver.unsubscribe(this);
+    _routeObserver?.unsubscribe(this);
+    _routeObserver = null;
     super.dispose();
   }
 
@@ -120,7 +130,6 @@ class _RecordSelectMomentState extends State<RecordSelectMoment>
     final now = "${day.month}월 ${day.day}일 ${dayTransformer[day.weekday - 1]}";
     final nowTimes = "${day.hour}시${day.minute}분";
 
-    // 필요하다면 Provider를 통해 RecordContext에서 emotion 값을 가져와 Palette에 접근
     final recordContext = Provider.of<RecordContext>(context);
     final currentPalette = palette[recordContext.emotion];
 


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- #3 

## 📋 변경 사항

- 하단 탭을 관리하기 위한 상태 클래스인 `AppState` 를 생성했습니다.
- 라우트 옵저버를 통해 페이지 변경을 감지하여 하단 탭의 표시 여부를 정하는 `BottomTabRouteObserver` 를 생성했습니다.
- `bottom_tab.dart`의 `build` 부분에 `Consumer<AppState>`를 통해 하단 탭 표시 여부를 결정합니다.
- 각 페이지에서 하단 탭이 필요없다면 `RouteAware`를 _* with RouteAware를 통해 받아오고 `didChangeDependencies()`와 `dispose` 를 오버라이드하여 구현합니다.
- GlobalKey대신 ValueKey를 통해 네비게이션 키를 생성합니다.
- 순간 선택 페이지에서 `WidgetBinding`을 통해 `false`로 변경하고 마지막 페이지에서 다시 `true`로 변경 후 페이지를 이동합니다.
- 감정기록 첫 페이지에서 뒤로가거나 감정기록 중 취소를 눌러 홈으로 이동했을 때 하단 탭이 안 보이는 현상 수정했습니다.

## 📝 참고 자료

- https://onlyfor-me-blog.tistory.com/1110
- https://www.flutteroverflow.in/2024/02/duplicate-globalkey-detected-in-widget.html

##  🏷️ 추후 변경 사항
- 현재 `BottomTabObserver`에 문제가 있어 Provider에서 정상적으로 동작하지 않는 현상이 있어 수정할 예정입니다.
- UniqueKey로 하는 방법도 있었으나,  ValueKey로 설정했습니다.