### PR TITLE
style: 모달 형식의 감정 기록 캘린더로 변경

### DIFF
--- a/lib/features/emotion-calendar/ui/emotion-calendar-button.dart
+++ b/lib/features/emotion-calendar/ui/emotion-calendar-button.dart
@@ -1,51 +1,94 @@
-import 'package:fapp/pages/emotion-calendar-page.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:fapp/app_state.dart';
+import 'package:fapp/pages/emotion-calendar-page.dart';
 
 class EmotionCalendarButton extends StatelessWidget {
   const EmotionCalendarButton({super.key});
 
+  void _handleShowEmotionCalendar(BuildContext context) {
+    final appState = Provider.of<AppState>(context, listen: false);
+    appState.setBottomTabVisibility(false);
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder:
+          (modalContext) => Container(
+            height: MediaQuery.of(context).size.height * 0.87,
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(20),
+                topRight: Radius.circular(20),
+              ),
+            ),
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 12,
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      const SizedBox(width: 40),
+                      const Text(
+                        "감정 캘린더",
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          color: Color(0xff3E3A39),
+                        ),
+                      ),
+                      InkWell(
+                        onTap: () => Navigator.pop(context),
+                        child: const SizedBox(
+                          width: 40,
+                          child: Text(
+                            '완료',
+                            textAlign: TextAlign.end,
+                            style: TextStyle(
+                              color: Color(0xff8749EB),
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Expanded(child: EmotionCalendarPage()),
+              ],
+            ),
+          ),
+    ).then((_) {
+      appState.setBottomTabVisibility(true);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        Navigator.of(context).push(
-          PageRouteBuilder(
-            opaque: false,
-            barrierColor: Colors.transparent,
-            transitionDuration: Duration(milliseconds: 300),
-            pageBuilder:
-                (context, animation, secondaryAnimation) =>
-                    EmotionCalendarPage(),
-            transitionsBuilder: (
-              context,
-              animation,
-              secondaryAnimation,
-              child,
-            ) {
-              final offset = Tween<Offset>(
-                begin: const Offset(0, 1),
-                end: const Offset(0, 0),
-              ).animate(
-                CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
-              );
-              return SlideTransition(position: offset, child: child);
-            },
-          ),
-        );
-      },
+      onTap: () => {_handleShowEmotionCalendar(context)},
       child: Container(
-        margin: EdgeInsets.fromLTRB(20, 10, 20, 20),
-        padding: EdgeInsets.fromLTRB(0, 14, 0, 14),
+        margin: const EdgeInsets.fromLTRB(20, 10, 20, 20),
+        padding: const EdgeInsets.fromLTRB(0, 14, 0, 14),
         decoration: BoxDecoration(
-          color: Color(0xffDCDDDD),
+          color: const Color(0xffDCDDDD),
           borderRadius: BorderRadius.circular(12),
         ),
-
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.calendar_month, size: 16),
-            Text(
+            const Icon(Icons.calendar_month, size: 16),
+            const SizedBox(
+              width: 8,
+            ), // Added a small space between icon and text
+            const Text(
               "감정 캘린더",
               style: TextStyle(
                 color: Color(0xff3E3A39),

--- a/lib/features/emotion-calendar/ui/emotion-calendar-navtop.dart
+++ b/lib/features/emotion-calendar/ui/emotion-calendar-navtop.dart
@@ -5,33 +5,45 @@ class EmotionCalendarNavTop extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Container(width: 40),
-        const Text(
-          "감정 캘린더",
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-            color: Color(0xff3E3A39),
-          ),
+    return Container(
+      decoration: const BoxDecoration(
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(40),
+          topRight: Radius.circular(40),
         ),
-        InkWell(
-          onTap: () => Navigator.pop(context),
-          child: SizedBox(
-            width: 40,
-            child: const Text(
-              '완료',
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const SizedBox(width: 40),
+            const Text(
+              "감정 캘린더",
               style: TextStyle(
-                color: Color(0xff8749EB),
                 fontSize: 16,
                 fontWeight: FontWeight.bold,
+                color: Color(0xff3E3A39),
               ),
             ),
-          ),
+            InkWell(
+              onTap: () => Navigator.pop(context),
+              child: const SizedBox(
+                width: 40,
+                child: Text(
+                  '완료',
+                  textAlign: TextAlign.end,
+                  style: TextStyle(
+                    color: Color(0xff8749EB),
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/lib/pages/emotion-calendar-page.dart
+++ b/lib/pages/emotion-calendar-page.dart
@@ -2,11 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:fapp/entities/emotion/models/emotion-types.dart';
 import 'package:fapp/features/emotion-calendar/ui/emotion-calendar-cell.dart';
-import 'package:fapp/features/emotion-calendar/ui/emotion-calendar-navtop.dart';
 import 'package:fapp/features/emotion-calendar/utils/weekday-util.dart';
 
 class EmotionCalendarPage extends StatefulWidget {
-  const EmotionCalendarPage({Key? key}) : super(key: key);
+  const EmotionCalendarPage({super.key});
 
   @override
   State<EmotionCalendarPage> createState() => _EmotionCalendarPageState();
@@ -28,98 +27,68 @@ class _EmotionCalendarPageState extends State<EmotionCalendarPage> {
   @override
   Widget build(BuildContext context) {
     return Material(
-      child: Align(
-        alignment: Alignment.topCenter,
-
-        child: Container(
-          height: MediaQuery.of(context).size.height * 0.95, // 위에 15% 여백
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-          ),
-          child: Container(
-            height: MediaQuery.of(context).size.height * 0.95,
-            padding: EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-            ),
-            child: SafeArea(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+      child: Container(
+        decoration: const BoxDecoration(color: Colors.white),
+        child: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children:
+                    WeekDayUtil.dayOfWeek
+                        .map((dayOfWeek) => Text(dayOfWeek))
+                        .toList(),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  EmotionCalendarNavTop(),
-                  SizedBox(height: 16),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceAround,
-                    children:
-                        WeekDayUtil.dayOfWeek
-                            .map((dayOfWeek) => Text(dayOfWeek))
-                            .toList(),
-                  ),
-
-                  SizedBox(height: 12),
-
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      Container(
-                        margin: EdgeInsets.fromLTRB(10, 0, 10, 0),
-                        child: Text(
-                          '${_focusedDay.month}월',
-                          style: TextStyle(
-                            fontSize: 24,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-
-                  SizedBox(height: 8),
-
-                  Expanded(
-                    child: TableCalendar(
-                      focusedDay: _focusedDay,
-                      firstDay: DateTime.utc(2010, 10, 16),
-                      lastDay: DateTime.utc(2030, 3, 14),
-                      headerVisible: false,
-                      rowHeight: 94,
-                      daysOfWeekHeight: 0,
-                      calendarStyle: CalendarStyle(
-                        outsideDaysVisible: false,
-                        cellMargin: EdgeInsets.zero,
-                      ),
-                      onPageChanged: (day) => setState(() => _focusedDay = day),
-                      calendarBuilders: CalendarBuilders(
-                        defaultBuilder: (context, day, focusedDay) {
-                          return EmotionCalendarCell(
-                            day: day,
-                            emotion:
-                                emotionData[DateTime(
-                                  day.year,
-                                  day.month,
-                                  day.day,
-                                )],
-                          );
-                        },
-                        todayBuilder: (context, day, focusedDay) {
-                          return EmotionCalendarCell(
-                            day: day,
-                            emotion:
-                                emotionData[DateTime(
-                                  day.year,
-                                  day.month,
-                                  day.day,
-                                )],
-                          );
-                        },
+                  Container(
+                    margin: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+                    child: Text(
+                      '${_focusedDay.month}월',
+                      style: const TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
                       ),
                     ),
                   ),
                 ],
               ),
-            ),
+              const SizedBox(height: 8),
+              Expanded(
+                child: TableCalendar(
+                  focusedDay: _focusedDay,
+                  firstDay: DateTime.utc(2010, 10, 16),
+                  lastDay: DateTime.utc(2030, 3, 14),
+                  headerVisible: false,
+                  rowHeight: 94,
+                  daysOfWeekHeight: 0,
+                  calendarStyle: CalendarStyle(
+                    outsideDaysVisible: false,
+                    cellMargin: EdgeInsets.zero,
+                  ),
+                  onPageChanged: (day) => setState(() => _focusedDay = day),
+                  calendarBuilders: CalendarBuilders(
+                    defaultBuilder: (context, day, focusedDay) {
+                      return EmotionCalendarCell(
+                        day: day,
+                        emotion:
+                            emotionData[DateTime(day.year, day.month, day.day)],
+                      );
+                    },
+                    todayBuilder: (context, day, focusedDay) {
+                      return EmotionCalendarCell(
+                        day: day,
+                        emotion:
+                            emotionData[DateTime(day.year, day.month, day.day)],
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/screens/emotion_home.dart
+++ b/lib/screens/emotion_home.dart
@@ -1,7 +1,6 @@
 import 'package:fapp/emotion/emotion_summary_container.dart';
 import 'package:fapp/features/emotion-calendar/ui/emotion-calendar-button.dart';
 import 'package:fapp/mock/emotion_summary.dart';
-import 'package:fapp/pages/emotion-calendar-page.dart';
 import 'package:flutter/material.dart';
 import 'package:fapp/biodashboard/biodashboard.dart';
 


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- #8 

## 🏞️ 첨부 파일
![image](https://github.com/user-attachments/assets/56783fd5-48b0-4982-abe1-7a530d545242)



## 📋 변경 사항

- 기존 페이지 형태로 구현되있던 캘린더를 `Expanded`로 받아 `showModalBottomSheet`에 넣었습니다.
- 처음 디자인된 형태와 유사하게 되었습니다.
